### PR TITLE
Updating docs on manually processing stream HTML

### DIFF
--- a/_source/reference/streams.md
+++ b/_source/reference/streams.md
@@ -106,6 +106,6 @@ To target multiple elements with a single action, use the `targets` attribute wi
 
 ## Processing Stream Elements
 
-Turbo can connected to any form of stream to receive and process stream actions. A stream source must dispatch [MessageEvent](https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent) messages that contain the stream action HTML in the `data` attribute of that event. It's then connected by `Turbo.session.connectStreamSource(source)` and disconnected via `Turbo.session.disconnectStreamSource(source)`. If you need to process stream actions from different source than something producing `MessageEvent`s, you can use `Turbo.session.receiveMessageHTML(streamActionHTML)` to do so.
+Turbo can connected to any form of stream to receive and process stream actions. A stream source must dispatch [MessageEvent](https://developer.mozilla.org/en-US/docs/Web/API/MessageEvent) messages that contain the stream action HTML in the `data` attribute of that event. It's then connected by `Turbo.session.connectStreamSource(source)` and disconnected via `Turbo.session.disconnectStreamSource(source)`. If you need to process stream actions from different source than something producing `MessageEvent`s, you can use `Turbo.session.streamObserver.receiveMessageHTML(streamActionHTML)` to do so.
 
 A good way to wrap all this together is by using a custom element, like turbo-rails does with [TurboCableStreamSourceElement](https://github.com/hotwired/turbo-rails/blob/main/app/javascript/turbo/cable_stream_source_element.js).


### PR DESCRIPTION
Calling `Turbo.session.streamObserver.receiveMessageHTML()` works for me, while `Turbo.session.receiveMessageHTML()` raises an error "Turbo.session.receiveMessageHTML is not a function."

To be more exact, I'm calling `window.Turbo.session.streamObserver.receiveMessageHTML` since importing `@hotwired/turbo-rails` sets `window.Turbo`, but not sure if you all want to add that as well. 